### PR TITLE
Fix libusb deprecated API build warning

### DIFF
--- a/usbisp/main.c
+++ b/usbisp/main.c
@@ -181,7 +181,7 @@ int main(int argc, char **argv)
 
 	/* Set debugging output to max level.
 	 */
-	libusb_set_debug(NULL, 3);
+	libusb_set_option(NULL, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_INFO);
 
 	/* Look for a specific device and open it.
 	 */


### PR DESCRIPTION
'make' produces the build warning:

```
main.c: In function ‘main’:
main.c:184:2: warning: ‘libusb_set_debug’ is deprecated:
Use libusb_set_option instead [-Wdeprecated-declarations]
  libusb_set_debug(NULL, 3);
  ^~~~~~~~~~~~~~~~
In file included from main.c:24:0:
/usr/include/libusb-1.0/libusb.h:1300:18: note: declared here
 void LIBUSB_CALL libusb_set_debug(libusb_context *ctx, int level);
                  ^~~~~~~~~~~~~~~~
```

Use the current 'libusb_set_option()' API.