### PR TITLE
Fix typo in switch case for usage printing (-h option)

### DIFF
--- a/usbisp/main.c
+++ b/usbisp/main.c
@@ -209,7 +209,7 @@ int main(int argc, char **argv)
 			case 'n':
 				require_protocol_v2 = 1;
 				break;
-			vdefault:
+			default:
 				printusage(argv[0]);
 				exit(0);
 				break;


### PR DESCRIPTION
Fix a typo to allow printing usage with -h argument.
Related to #10 and #12 